### PR TITLE
JOSS: minor editing and bib fixes; add Jupyter and Binder citations

### DIFF
--- a/JOSS/paper.bib
+++ b/JOSS/paper.bib
@@ -2,7 +2,7 @@
 
 @Conference{Hornby-GECCO-2006,
   author    = {Gregory S. Hornby},
-  title     = {{ALPS: The Age-Layered Population Structure for Reducing the Problem of Premature Convergence}},
+  title     = {{ALPS}: The Age-Layered Population Structure for Reducing the Problem of Premature Convergence},
   booktitle = {GECCO 2006},
   year      = {2006},
   doi       = {10.1145/1143997.1144142}
@@ -10,7 +10,7 @@
 
 @Conference{Hornby-GECCO-2009-ALPSsteady,
   author    = {Gregory S. Hornby},
-  title     = {{Steady-State ALPS for Real-Valued Problems}},
+  title     = {Steady-State {ALPS} for Real-Valued Problems},
   booktitle = {GECCO 2009},
   year      = {2009},
   doi       = {10.1145/1569901.1570011},
@@ -18,7 +18,7 @@
 
 @Conference{Hornby-GECCO-2009-ALPSgeneral,
   author    = {Gregory S. Hornby},
-  title     = {{The Age-Layered Population Structure (ALPS) Evolutionary Algorithm}},
+  title     = {The Age-Layered Population Structure ({ALPS}) Evolutionary Algorithm},
   booktitle = {GECCO 2009},
   year      = {2009},
 }
@@ -37,6 +37,28 @@
   url       = {http://ipython.org},
 }
 
+@conference{Kluyver:2016aa,
+  author       = {Thomas Kluyver and Benjamin Ragan-Kelley and Fernando P{\'e}rez and Brian Granger and Matthias Bussonnier and Jonathan Frederic and Kyle Kelley and Jessica Hamrick and Jason Grout and Sylvain Corlay and Paul Ivanov and Dami{\'a}n Avila and Safia Abdalla and Carol Willing},
+  booktitle    = {Positioning and Power in Academic Publishing: Players, Agents and Agendas},
+  editor       = {F. Loizides and B. Schmidt},
+  organization = {IOS Press},
+  pages        = {87--90},
+  title        = {Jupyter Notebooks - A publishing format for reproducible computational workflows},
+  year         = {2016},
+  doi          = {10.3233/978-1-61499-649-1-87},
+}
+
+
+@InProceedings{jupyter2018binder,
+  author    = {{P}roject {J}upyter and {M}atthias {B}ussonnier and {J}essica {F}orde and {J}eremy {F}reeman and {B}rian {G}ranger and {T}im {H}ead and {C}hris {H}oldgraf and {K}yle {K}elley and {G}ladys {N}alvarte and {A}ndrew {O}sheroff and {M} {P}acer and {Y}uvi {P}anda and {F}ernando {P}erez and {B}enjamin {R}agan-{K}elley and {C}arol {W}illing},
+  title     = {{B}inder 2.0 - {R}eproducible, interactive, sharable environments for science at scale},
+  booktitle = {{P}roceedings of the 17th {P}ython in {S}cience {C}onference},
+  pages     = {113 - 120},
+  year      = {2018},
+  editor    = {{F}atih {A}kici and {D}avid {L}ippa and {D}illon {N}iederhut and {M} {P}acer},
+  doi       = {10.25080/Majora-4af1f417-011},
+}
+
 @Article{Sandgren-JMD-1990,
   author    = {E. Sandgren},
   title     = {Nonlinear Integer and Discrete Programming in Mechanical Design Optimization},
@@ -51,7 +73,7 @@
 
 @Article{Storn-JGO-1997,
   author  = {Rainer Storn and Kenneth Price},
-  title   = {{Differential Evolution -- A Simple and Efficient Heuristic for Global Optimization over Continuous Spaces}},
+  title   = {Differential Evolution: A Simple and Efficient Heuristic for Global Optimization over Continuous Spaces},
   journal = {J. Global Opt.},
   year    = {1997},
   volume  = {11},

--- a/JOSS/paper.md
+++ b/JOSS/paper.md
@@ -22,22 +22,22 @@ CEGO (C++11 Evolutionary Global Optimization) is a C++11-based optimization libr
 
 A brief summary of the functionality of CEGO includes:
 
-* The implementation of the ALPS algorithm [@Hornby-GECCO-2006,@Hornby-GECCO-2009-ALPSsteady,@Hornby-GECCO-2009-ALPSgeneral] for age-layering several optimization runs together.  The layers interface is based on migration of younger individuals in the population into older layers.  If the individual is too old, and does not dominate another individual in its next layer, it is removed from the population.  Age layering can be disabled through the use of a single-layer if desired.
-* Latin-hypercube sampling to generate the initial population of individuals in the population.
-* A generic architecture for evolving the layered population(s).  In the current version, differential evolution [@Storn-JGO-1997] is the default evolving method, though an extensible API is available that allows for plug-and-play of alternative population evolution methods.  Flags for the evolver are handled in a generic way with a Javascript Object Notation (JSON) structure.
+* The implementation of the ALPS algorithm [@Hornby-GECCO-2006;@Hornby-GECCO-2009-ALPSsteady;@Hornby-GECCO-2009-ALPSgeneral] for age-layering several optimization runs together.  The layers interface is based on migration of younger individuals in the population into older layers.  If the individual is too old, and does not dominate another individual in its next layer, it is removed from the population.  Age layering can be disabled through the use of a single layer if desired.
+* Latin hypercube sampling to generate the initial population of individuals in the population.
+* A generic architecture for evolving the layered population(s).  In the current version, differential evolution [@Storn-JGO-1997] is the default evolving method, though an extensible API is available that allows for plug-and-play of alternative population evolution methods.  Flags for the evolver are handled in a generic way with a JavaScript Object Notation (JSON) structure.
 * Use of native C++11 threads (with a thread pool) to parallelize the evaluation of the cost function, allowing for a nearly-linear speedup as more computational cores are made available.
 * Ability to log all inputs and outputs (along with an optional filtering function) for further analysis of the progress of the optimization.
 * A single-threaded Python wrapper (``PyCEGO``) is written with ``pybind11``^[https://github.com/pybind/pybind11] and is used to demonstrate the functionality of the library, though it cannot fully leverage the parallelism available in CEGO at the C++ level.
 
-A few ``Jupyter`` notebooks [@ipython] are provided as examples that implement:
+A few ``Jupyter`` notebooks [@ipython;@Kluyver:2016aa] are provided as examples that implement:
 
 A) optimization of cost functions of two- and ten-dimensional continuous variables.
 B) the mixed-integer nonlinear optimization problems of the constrained optimization of a pressure vessel mass and dimensionally-constrained spring [@Sandgren-JMD-1990]
 C) inverse modeling of Gaussian bumps.  
 
-All global optimization problems successfully obtain the minimum value from the literature, or better.  Furthermore, a ``binder``^[https://mybinder.org/] environment has been configured such that the Jupyter notebooks can be run interactively in an internet browser without any installation on the user's computer.
+All global optimization problems successfully obtain the minimum value from the literature, or better.  Furthermore, a ``binder`` [@jupyter2018binder] environment has been configured such that the Jupyter notebooks can be run interactively in an internet browser without any installation on the user's computer.
 
-An example is given here of the global optimization of the modified hundred-digit optimization problem [@Townsend-THESIS],(Eq. 5.15), a function with 9,318 different local minima in [-1,1] x [-1,1].  CEGO finds the correct global minimum value of −3.398166873463248.
+An example is given here of the global optimization of the modified hundred-digit optimization problem [@Townsend-THESIS, Eq. 5.15], a function with 9,318 different local minima in $[-1,1] \times [-1,1]$.  CEGO finds the correct global minimum value of −3.398166873463248.
 
 ``` python
 from numpy import exp, sin


### PR DESCRIPTION
See https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax for syntax.

https://github.com/jupyter/jupyter/issues/190
https://mybinder.readthedocs.io/en/latest/#citing-binder

I can't find a record of `Hornby-GECCO-2009-ALPSgeneral` (http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.338.4656&rep=rep1&type=pdf) having been published. This appears to be the complete proceeding:
https://dblp.uni-trier.de/db/conf/gecco/gecco2009.html

Cc: https://github.com/openjournals/joss-reviews/issues/1147